### PR TITLE
Remove CHMOD from install script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
         "": {
             "name": "folder2txt",
             "version": "1.0.1",
-            "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
                 "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
     },
     "type": "module",
     "scripts": {
-        "test": "chmod +x folder2txt.js && ava",
-        "prepare": "chmod +x folder2txt.js",
-        "postinstall": "chmod +x folder2txt.js"
+        "test": "ava"
     },
     "keywords": [
         "cli",


### PR DESCRIPTION
Fixes #3

Tested on Windows, install works, execution using the shim that npm auto-generate works:

```
$ npm install -g .

added 1 package in 328ms

$ Get-Command folder2txt -all

CommandType     Name                                               Version    Source
-----------     ----                                               -------    ------
ExternalScript  folder2txt.ps1                                                C:\Users\darth\scoop\apps\nodejs\current\bin\folder2txt.ps1
Application     folder2txt.cmd                                     0.0.0.0    C:\Users\darth\scoop\apps\nodejs\current\bin\folder2txt.cmd
Application     folder2txt                                         0.0.0.0    C:\Users\darth\scoop\apps\nodejs\current\bin\folder2txt

$ mkdir test-folder
$ cd test-folder
$ echo "A" > a.txt
$ echo "B" > b.txt
$ folder2txt
√ Processed 2 files (0 skipped)
√ Output saved to output.txt
$ cat .\output.txt

================================================================================
File: a.txt
Size: 3 B
================================================================================

A

================================================================================
File: b.txt
Size: 3 B
================================================================================

B
```

Also, tested on macOS, install and execution still work. (I see `folder2txt.js` is already executable.)